### PR TITLE
Support for non-multiple of 8 numbers of bits in network mask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ kubectl
 go-test-tmpfile*
 coverage.txt
 .idea
+.vscode

--- a/core/dnsserver/address.go
+++ b/core/dnsserver/address.go
@@ -31,15 +31,15 @@ func (z zoneAddr) String() string {
 
 // normalizeZone parses an zone string into a structured format with separate
 // host, and port portions, as well as the original input string.
-func normalizeZone(str string) (zoneAddr, error) {
+func normalizeZone(str string) ([]zoneAddr, error) {
 	var err error
 
 	var trans string
 	trans, str = parse.Transport(str)
 
-	host, port, ipnet, err := plugin.SplitHostPort(str)
+	hosts, port, ipnet, err := plugin.SplitHostPort(str)
 	if err != nil {
-		return zoneAddr{}, err
+		return []zoneAddr{zoneAddr{}}, err
 	}
 
 	if port == "" {
@@ -54,8 +54,11 @@ func normalizeZone(str string) (zoneAddr, error) {
 			port = transport.HTTPSPort
 		}
 	}
-
-	return zoneAddr{Zone: dns.Fqdn(host), Port: port, Transport: trans, IPNet: ipnet}, nil
+	var zas []zoneAddr
+	for _, host := range hosts {
+		zas = append(zas, zoneAddr{Zone: dns.Fqdn(host), Port: port, Transport: trans, IPNet: ipnet})
+	}
+	return zas, nil
 }
 
 // SplitProtocolHostPort splits a full formed address like "dns://[::1]:53" into parts.

--- a/core/dnsserver/address_test.go
+++ b/core/dnsserver/address_test.go
@@ -9,6 +9,25 @@ func TestNormalizeReverseZoneWithExpansion(t *testing.T) {
 		shouldErr bool
 	}{
 		{"10.6.84.129/31", []string{"dns://128.84.6.10.in-addr.arpa.:53", "dns://129.84.6.10.in-addr.arpa.:53"}, false},
+		{"172.17.17.17/12",
+			[]string{
+				"dns://16.172.in-addr.arpa.:53",
+				"dns://17.172.in-addr.arpa.:53",
+				"dns://18.172.in-addr.arpa.:53",
+				"dns://19.172.in-addr.arpa.:53",
+				"dns://20.172.in-addr.arpa.:53",
+				"dns://21.172.in-addr.arpa.:53",
+				"dns://22.172.in-addr.arpa.:53",
+				"dns://23.172.in-addr.arpa.:53",
+				"dns://24.172.in-addr.arpa.:53",
+				"dns://25.172.in-addr.arpa.:53",
+				"dns://26.172.in-addr.arpa.:53",
+				"dns://27.172.in-addr.arpa.:53",
+				"dns://28.172.in-addr.arpa.:53",
+				"dns://29.172.in-addr.arpa.:53",
+				"dns://30.172.in-addr.arpa.:53",
+				"dns://31.172.in-addr.arpa.:53",
+			}, false},
 	} {
 		hosts, err := normalizeZone(test.input)
 		var actual []string
@@ -22,7 +41,7 @@ func TestNormalizeReverseZoneWithExpansion(t *testing.T) {
 			t.Errorf("Test %d: Expected no error, but there was one: %v", i, err)
 		}
 		if len(actual) != len(test.expected) {
-			t.Errorf("Test %d: Expected %v, but %v observed", i, test.expected, actual)
+			t.Errorf("Test %d: Expected %d elements but %d observed", i, len(test.expected), len(actual))
 		} else {
 			for ih, host := range actual {
 				if host != test.expected[ih] {

--- a/core/dnsserver/address_test.go
+++ b/core/dnsserver/address_test.go
@@ -30,7 +30,7 @@ func TestNormalizeZone(t *testing.T) {
 		{"https://.:", "://:", true},
 	} {
 		addr, err := normalizeZone(test.input)
-		actual := addr.String()
+		actual := addr[0].String()
 		if test.shouldErr && err == nil {
 			t.Errorf("Test %d: Expected error, but there wasn't any", i)
 		}
@@ -66,7 +66,7 @@ func TestNormalizeZoneReverse(t *testing.T) {
 		{"fd00:77:30::0/110", "dns://0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.3.0.0.7.7.0.0.0.0.d.f.ip6.arpa.:53", false},
 	} {
 		addr, err := normalizeZone(test.input)
-		actual := addr.String()
+		actual := addr[0].String()
 		if test.shouldErr && err == nil {
 			t.Errorf("Test %d: Expected error, but there wasn't any", i)
 		}

--- a/core/dnsserver/address_test.go
+++ b/core/dnsserver/address_test.go
@@ -2,6 +2,37 @@ package dnsserver
 
 import "testing"
 
+func TestNormalizeReverseZoneWithExpansion(t *testing.T) {
+	for i, test := range []struct {
+		input     string
+		expected  []string
+		shouldErr bool
+	}{
+		{"10.6.84.129/31", []string{"dns://128.84.6.10.in-addr.arpa.:53", "dns://129.84.6.10.in-addr.arpa.:53"}, false},
+	} {
+		hosts, err := normalizeZone(test.input)
+		var actual []string
+		for _, host := range hosts {
+			actual = append(actual, host.String())
+		}
+		if test.shouldErr && err == nil {
+			t.Errorf("Test %d: Expected error, but there wasn't any", i)
+		}
+		if !test.shouldErr && err != nil {
+			t.Errorf("Test %d: Expected no error, but there was one: %v", i, err)
+		}
+		if len(actual) != len(test.expected) {
+			t.Errorf("Test %d: Expected %v, but %v observed", i, test.expected, actual)
+		} else {
+			for ih, host := range actual {
+				if host != test.expected[ih] {
+					t.Errorf("Test %d: Expected %s at index %d but got %s", i, test.expected[ih], ih, host)
+				}
+			}
+		}
+	}
+}
+
 func TestNormalizeZone(t *testing.T) {
 	for i, test := range []struct {
 		input     string

--- a/plugin/auto/setup.go
+++ b/plugin/auto/setup.go
@@ -93,9 +93,12 @@ func autoParse(c *caddy.Controller) (Auto, error) {
 		if len(args) > 0 {
 			a.Zones.origins = args
 		}
+
+		var normalizedOrigins []string
 		for i := range a.Zones.origins {
-			a.Zones.origins[i] = plugin.Host(a.Zones.origins[i]).Normalize()
+			normalizedOrigins = append(normalizedOrigins, plugin.Host(a.Zones.origins[i]).Normalize()...)
 		}
+		a.Zones.origins = normalizedOrigins
 
 		for c.NextBlock() {
 			switch c.Val() {

--- a/plugin/autopath/setup.go
+++ b/plugin/autopath/setup.go
@@ -79,9 +79,11 @@ func autoPathParse(c *caddy.Controller) (*AutoPath, string, error) {
 			ap.Zones = make([]string, len(c.ServerBlockKeys))
 			copy(ap.Zones, c.ServerBlockKeys)
 		}
-		for i, str := range ap.Zones {
-			ap.Zones[i] = plugin.Host(str).Normalize()
+		var zones []string
+		for _, str := range ap.Zones {
+			zones = append(zones, plugin.Host(str).Normalize()...)
 		}
+		ap.Zones = zones
 	}
 	return ap, mw, nil
 }

--- a/plugin/cache/setup.go
+++ b/plugin/cache/setup.go
@@ -185,11 +185,11 @@ func cacheParse(c *caddy.Controller) (*Cache, error) {
 				return nil, c.ArgErr()
 			}
 		}
-
+		var zones []string
 		for i := range origins {
-			origins[i] = plugin.Host(origins[i]).Normalize()
+			zones = append(zones, plugin.Host(origins[i]).Normalize()...)
 		}
-		ca.Zones = origins
+		ca.Zones = zones
 
 		ca.pcache = cache.New(ca.pcap)
 		ca.ncache = cache.New(ca.ncap)

--- a/plugin/dnssec/setup.go
+++ b/plugin/dnssec/setup.go
@@ -91,7 +91,8 @@ func dnssecParse(c *caddy.Controller) ([]string, []*DNSKEY, int, bool, error) {
 		}
 	}
 	for i := range zones {
-		zones[i] = plugin.Host(zones[i]).Normalize()
+		//We don't expect zone expantion after Normalize
+		zones[i] = plugin.Host(zones[i]).Normalize()[0]
 	}
 
 	// Check if we have both KSKs and ZSKs.

--- a/plugin/etcd/setup.go
+++ b/plugin/etcd/setup.go
@@ -66,9 +66,11 @@ func etcdParse(c *caddy.Controller) (*Etcd, bool, error) {
 			etc.Zones = make([]string, len(c.ServerBlockKeys))
 			copy(etc.Zones, c.ServerBlockKeys)
 		}
-		for i, str := range etc.Zones {
-			etc.Zones[i] = plugin.Host(str).Normalize()
+		var zones []string
+		for _, str := range etc.Zones {
+			zones = append(zones, plugin.Host(str).Normalize()...)
 		}
+		etc.Zones = zones
 
 		if c.NextBlock() {
 			for {

--- a/plugin/federation/setup.go
+++ b/plugin/federation/setup.go
@@ -80,11 +80,12 @@ func federationParse(c *caddy.Controller) (*Federation, error) {
 			}
 		}
 
+		var normalizedOrigins []string
 		for i := range origins {
-			origins[i] = plugin.Host(origins[i]).Normalize()
+			normalizedOrigins = append(normalizedOrigins, plugin.Host(origins[i]).Normalize()...)
 		}
 
-		fed.zones = origins
+		fed.zones = normalizedOrigins
 
 		if len(fed.f) == 0 {
 			return fed, fmt.Errorf("at least one name to zone federation expected")

--- a/plugin/file/setup.go
+++ b/plugin/file/setup.go
@@ -82,7 +82,8 @@ func fileParse(c *caddy.Controller) (Zones, error) {
 		}
 
 		for i := range origins {
-			origins[i] = plugin.Host(origins[i]).Normalize()
+			//For file plugin, we don't expect Normalize would expand the host
+			origins[i] = plugin.Host(origins[i]).Normalize()[0]
 			zone, err := Parse(reader, origins[i], fileName, 0)
 			if err == nil {
 				z[origins[i]] = zone

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -94,7 +94,8 @@ func ParseForwardStanza(c *caddyfile.Dispenser) (*Forward, error) {
 	if !c.Args(&f.from) {
 		return f, c.ArgErr()
 	}
-	f.from = plugin.Host(f.from).Normalize()
+	//We don't expect Normalize to expand
+	f.from = plugin.Host(f.from).Normalize()[0]
 
 	to := c.RemainingArgs()
 	if len(to) == 0 {
@@ -141,7 +142,8 @@ func parseBlock(c *caddyfile.Dispenser, f *Forward) error {
 			return c.ArgErr()
 		}
 		for i := 0; i < len(ignore); i++ {
-			ignore[i] = plugin.Host(ignore[i]).Normalize()
+			//TODO: shall we expect expanded hosts here?
+			ignore[i] = plugin.Host(ignore[i]).Normalize()[0]
 		}
 		f.ignored = ignore
 	case "max_fails":

--- a/plugin/hosts/setup.go
+++ b/plugin/hosts/setup.go
@@ -105,10 +105,12 @@ func hostsParse(c *caddy.Controller) (Hosts, error) {
 			origins = args
 		}
 
+		var normalizedOrigins []string
 		for i := range origins {
-			origins[i] = plugin.Host(origins[i]).Normalize()
+			normalizedOrigins = append(normalizedOrigins, plugin.Host(origins[i]).Normalize()...)
 		}
-		h.Origins = origins
+
+		h.Origins = normalizedOrigins
 
 		for c.NextBlock() {
 			switch c.Val() {

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -135,19 +135,18 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 	}
 	k8s.opts = opts
 
-	zones := c.RemainingArgs()
-
-	if len(zones) != 0 {
-		k8s.Zones = zones
-		for i := 0; i < len(k8s.Zones); i++ {
-			k8s.Zones[i] = plugin.Host(k8s.Zones[i]).Normalize()
+	remainingArgs := c.RemainingArgs()
+	var zones []string
+	if len(remainingArgs) != 0 {
+		for i := 0; i < len(remainingArgs); i++ {
+			zones = append(zones, plugin.Host(remainingArgs[i]).Normalize()...)
 		}
 	} else {
-		k8s.Zones = make([]string, len(c.ServerBlockKeys))
 		for i := 0; i < len(c.ServerBlockKeys); i++ {
-			k8s.Zones[i] = plugin.Host(c.ServerBlockKeys[i]).Normalize()
+			zones = append(zones, plugin.Host(c.ServerBlockKeys[i]).Normalize()...)
 		}
 	}
+	k8s.Zones = zones
 
 	k8s.primaryZoneIndex = -1
 	for i, z := range k8s.Zones {

--- a/plugin/loop/setup.go
+++ b/plugin/loop/setup.go
@@ -75,7 +75,8 @@ func parse(c *caddy.Controller) (*Loop, error) {
 		}
 
 		if len(c.ServerBlockKeys) > 0 {
-			zone = plugin.Host(c.ServerBlockKeys[0]).Normalize()
+			//For loop plugin, we don't expect expansion of host into a few entries
+			zone = plugin.Host(c.ServerBlockKeys[0]).Normalize()[0]
 		}
 	}
 	return New(zone), nil

--- a/plugin/metadata/setup.go
+++ b/plugin/metadata/setup.go
@@ -42,15 +42,14 @@ func metadataParse(c *caddy.Controller) (*Metadata, error) {
 	c.Next()
 	zones := c.RemainingArgs()
 
+	m.Zones = []string{}
 	if len(zones) != 0 {
-		m.Zones = zones
 		for i := 0; i < len(m.Zones); i++ {
-			m.Zones[i] = plugin.Host(m.Zones[i]).Normalize()
+			m.Zones = append(m.Zones, plugin.Host(m.Zones[i]).Normalize()...)
 		}
 	} else {
-		m.Zones = make([]string, len(c.ServerBlockKeys))
 		for i := 0; i < len(c.ServerBlockKeys); i++ {
-			m.Zones[i] = plugin.Host(c.ServerBlockKeys[i]).Normalize()
+			m.Zones = append(m.Zones, plugin.Host(c.ServerBlockKeys[i]).Normalize()...)
 		}
 	}
 

--- a/plugin/metrics/metrics.go
+++ b/plugin/metrics/metrics.go
@@ -67,6 +67,16 @@ func (m *Metrics) AddZone(z string) {
 	m.zoneMu.Unlock()
 }
 
+// AddZones adds zones from zs to m.
+func (m *Metrics) AddZones(zs []string) {
+	m.zoneMu.Lock()
+	for _, z := range zs {
+		m.zoneMap[z] = true
+	}
+	m.zoneNames = keys(m.zoneMap)
+	m.zoneMu.Unlock()
+}
+
 // RemoveZone remove zone z from m.
 func (m *Metrics) RemoveZone(z string) {
 	m.zoneMu.Lock()

--- a/plugin/metrics/setup.go
+++ b/plugin/metrics/setup.go
@@ -67,7 +67,7 @@ func prometheusParse(c *caddy.Controller) (*Metrics, error) {
 		i++
 
 		for _, z := range c.ServerBlockKeys {
-			met.AddZone(plugin.Host(z).Normalize())
+			met.AddZones(plugin.Host(z).Normalize())
 		}
 		args := c.RemainingArgs()
 

--- a/plugin/normalize.go
+++ b/plugin/normalize.go
@@ -131,7 +131,7 @@ func SplitHostPort(s string) (hosts []string, port string, ipnet *net.IPNet, err
 					break
 				}
 			}
-			hosts = append(hosts, rev[offset:])
+			hosts = []string{rev[offset:]}
 		}
 		//}
 	}

--- a/plugin/normalize.go
+++ b/plugin/normalize.go
@@ -78,11 +78,12 @@ func (h Host) Normalize() []string {
 // String the string s should *not* be prefixed with any protocols, i.e. dns://. The returned ipnet is the
 // *net.IPNet that is used when the zone is a reverse and a netmask is given.
 func SplitHostPort(s string) (hosts []string, port string, ipnet *net.IPNet, err error) {
+	host := s
+	hosts = []string{s}
+
 	// If there is: :[0-9]+ on the end we assume this is the port. This works for (ascii) domain
 	// names and our reverse syntax, which always needs a /mask *before* the port.
 	// So from the back, find first colon, and then check if its a number.
-	host := s
-
 	colon := strings.LastIndex(s, ":")
 	if colon == len(s)-1 {
 		return []string{""}, "", nil, fmt.Errorf("expecting data after last colon: %q", s)

--- a/plugin/normalize.go
+++ b/plugin/normalize.go
@@ -106,14 +106,14 @@ func SplitHostPort(s string) (hosts []string, port string, ipnet *net.IPNet, err
 	}
 
 	// Check if it parses as a reverse zone, if so we use that. Must be fully specified IP and mask.
-	ip, n, err := net.ParseCIDR(host)
+	_, n, err := net.ParseCIDR(host) //ip is not used
 
 	if err == nil {
 		//for ip := range ips {
 
 		ones, bits := 0, 0
 
-		if rev, e := dns.ReverseAddr(ip.String()); e == nil {
+		if rev, e := dns.ReverseAddr(n.IP.String()); e == nil {
 			ones, bits = n.Mask.Size()
 			// get the size, in bits, of each portion of hostname defined in the reverse address. (8 for IPv4, 4 for IPv6)
 			sizeDigit := 8

--- a/plugin/normalize.go
+++ b/plugin/normalize.go
@@ -68,7 +68,7 @@ func (h Host) Normalize() []string {
 	// The error can be ignore here, because this function is called after the corefile has already been vetted.
 	hosts, _, _, _ := SplitHostPort(s)
 	var retval []string
-	for host := range hosts {
+	for _, host := range hosts {
 		retval = append(retval, Name(host).Normalize())
 	}
 	return retval
@@ -79,8 +79,6 @@ func (h Host) Normalize() []string {
 // *net.IPNet that is used when the zone is a reverse and a netmask is given.
 func SplitHostPort(s string) (hosts []string, port string, ipnet *net.IPNet, err error) {
 	host := s
-	hosts = []string{s}
-
 	// If there is: :[0-9]+ on the end we assume this is the port. This works for (ascii) domain
 	// names and our reverse syntax, which always needs a /mask *before* the port.
 	// So from the back, find first colon, and then check if its a number.
@@ -94,6 +92,7 @@ func SplitHostPort(s string) (hosts []string, port string, ipnet *net.IPNet, err
 			host = s[:colon]
 		}
 	}
+	hosts = []string{host}
 
 	// TODO(miek): this should take escaping into account.
 	if len(host) > 255 {

--- a/plugin/pkg/fall/fall.go
+++ b/plugin/pkg/fall/fall.go
@@ -19,8 +19,9 @@ func (f F) Through(qname string) bool {
 
 // setZones will set zones in f.
 func (f *F) setZones(zones []string) {
+	var normalizedZones []string
 	for i := range zones {
-		zones[i] = plugin.Host(zones[i]).Normalize()
+		normalizedZones = append(normalizedZones, plugin.Host(zones[i]).Normalize()...)
 	}
 	f.Zones = zones
 }

--- a/plugin/proxy/upstream.go
+++ b/plugin/proxy/upstream.go
@@ -52,7 +52,8 @@ func NewStaticUpstream(c *caddyfile.Dispenser) (Upstream, error) {
 	if !c.Args(&upstream.from) {
 		return upstream, c.ArgErr()
 	}
-	upstream.from = plugin.Host(upstream.from).Normalize()
+	//For proxy, we can use only one domain for "From"
+	upstream.from = plugin.Host(upstream.from).Normalize()[0]
 
 	to := c.RemainingArgs()
 	if len(to) == 0 {
@@ -137,12 +138,13 @@ func parseBlock(c *caddyfile.Dispenser, u *staticUpstream) error {
 			u.HealthCheck.Interval = dur
 		}
 	case "except":
-		ignoredDomains := c.RemainingArgs()
-		if len(ignoredDomains) == 0 {
+		remainingArgs := c.RemainingArgs()
+		if len(remainingArgs) == 0 {
 			return c.ArgErr()
 		}
-		for i := 0; i < len(ignoredDomains); i++ {
-			ignoredDomains[i] = plugin.Host(ignoredDomains[i]).Normalize()
+		var ignoredDomains []string
+		for i := 0; i < len(remainingArgs); i++ {
+			ignoredDomains = append(ignoredDomains, plugin.Host(remainingArgs[i]).Normalize()...)
 		}
 		u.IgnoredSubDomains = ignoredDomains
 	case "spray":

--- a/plugin/secondary/setup.go
+++ b/plugin/secondary/setup.go
@@ -60,8 +60,13 @@ func secondaryParse(c *caddy.Controller) (file.Zones, error) {
 			if len(args) > 0 {
 				origins = args
 			}
+			var normalizedOrigins []string
 			for i := range origins {
-				origins[i] = plugin.Host(origins[i]).Normalize()
+				normalizedOrigins = append(normalizedOrigins, plugin.Host(origins[i]).Normalize()...)
+			}
+			origins = normalizedOrigins
+
+			for i := range origins {
 				z[origins[i]] = file.NewZone(origins[i], "stdin")
 				names = append(names, origins[i])
 			}

--- a/plugin/template/setup.go
+++ b/plugin/template/setup.go
@@ -58,13 +58,14 @@ func templateParse(c *caddy.Controller) (handler Handler, err error) {
 			return handler, c.Errf("invalid RR class %s", c.Val())
 		}
 
-		zones := c.RemainingArgs()
-		if len(zones) == 0 {
+		remainingArgs := c.RemainingArgs()
+		var zones []string
+		if len(remainingArgs) == 0 {
 			zones = make([]string, len(c.ServerBlockKeys))
 			copy(zones, c.ServerBlockKeys)
 		}
-		for i, str := range zones {
-			zones[i] = plugin.Host(str).Normalize()
+		for _, str := range remainingArgs {
+			zones = append(zones, plugin.Host(str).Normalize()...)
 		}
 		handler.Zones = append(handler.Zones, zones...)
 


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
It's to have a correct substitution of reverse zones like "172.16.0.0/12" with a number of "in-addr.arpa" names.

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/2252

### 3. Which documentation changes (if any) need to be made?
We could probably describe in what plugins we may specify CIDR expressions like "172.16.0.0/12" and where such expressions are not allowed because of possibility to have a number of names generated.